### PR TITLE
Use `fd` to find files because it's faster

### DIFF
--- a/init.el
+++ b/init.el
@@ -186,7 +186,7 @@
          ("M-g i" . consult-imenu)
          ("M-g I" . consult-imenu-multi)
          ;; M-s bindings (search-map)
-         ("M-s d" . consult-find)
+         ("M-s d" . consult-fd)
          ("M-s D" . consult-locate)
          ("M-s g" . consult-grep)
          ("M-s G" . consult-git-grep)


### PR DESCRIPTION
See title, users will need to install `fd` via `cargo install fd-find`